### PR TITLE
Add support for three-typed Pokémon (Forest's Curse, Trick-or-Treat) to `@pkmn/data`

### DIFF
--- a/data/index.test.ts
+++ b/data/index.test.ts
@@ -539,9 +539,11 @@ for (const [pkg, Dex] of Object.entries(DATA)) {
         expect(gen.types.totalEffectiveness('Water', ['Fire'])).toBe(2);
         expect(gen.types.totalEffectiveness({type: 'Fire'}, 'Fire')).toBe(0.5);
         expect(gen.types.totalEffectiveness('Dark', ['Ghost', 'Psychic'])).toBe(4);
+        expect(gen.types.totalEffectiveness('Fire', ['Bug', 'Steel', 'Grass'])).toBe(8);
         expect(gen.types.get('Dark')!.totalEffectiveness(['Ghost', 'Psychic'])).toBe(4);
         expect(gen.types.get('Electric')!.totalEffectiveness('Ground')).toBe(0);
         expect(gen.types.get('Psychic')!.totalEffectiveness(['Ghost', 'Dark'])).toBe(0);
+        expect(gen.types.get('Grass')!.totalEffectiveness(['Fire', 'Steel', 'Grass'])).toBe(0.125);
         expect(gen.types.totalEffectiveness('Normal', {getTypes: () => ['Steel', 'Rock']}))
           .toBe(0.25);
         expect(gen.types.totalEffectiveness('Bug', 'Bug')).toBe(1);

--- a/data/index.ts
+++ b/data/index.ts
@@ -377,11 +377,13 @@ export class Natures {
 }
 
 const EFFECTIVENESS = {
+  '-3': 0.125,
   '-2': 0.25,
   '-1': 0.5,
   '0': 1,
   '1': 2,
   '2': 4,
+  '3': 8,
 };
 
 type TypeTarget = { getTypes: () => TypeName[] } | { types: TypeName[] } | TypeName[] | TypeName;


### PR DESCRIPTION
- `Type#totalEffectiveness` and `Types#totalEffectiveness` now account
  for the possibility of triple weakness and triple resistance.
- The associated tests account for the following:
    - Forretress (Bug/Steel-type) afflicted with Forest's Curse getting
      hit by a Fire-type attack. (8x damage)
    - Heatran (Fire/Steel-type) afflicted with Forest's Curse getting
      hit by a Grass-type attack. (0.125x damage)