### PR TITLE
@pkmn/data: Merge `Learnsets.learnable` data for evolved species

### DIFF
--- a/data/index.test.ts
+++ b/data/index.test.ts
@@ -455,6 +455,8 @@ for (const [pkg, Dex] of Object.entries(DATA)) {
           .toEqual(['4M']);
         expect((await Gen(5).learnsets.learnable('Ursaring'))!['rockclimb'])
           .toBeUndefined();
+        expect((await Gen(4).learnsets.learnable('Hitmonlee'))!['megakick'])
+          .toEqual(['4L49', '3T', '3L46', '3S0']);
       });
 
       it('#canLearn', async () => {

--- a/data/index.ts
+++ b/data/index.ts
@@ -590,7 +590,8 @@ export class Learnsets {
           if (move) {
             const sources = learnset.learnset[moveid];
             if (this.isLegal(move, sources, restriction || this.gen)) {
-              moves[move.id] = sources.filter(s => +s.charAt(0) <= this.gen.num);
+              const filtered = sources.filter(s => +s.charAt(0) <= this.gen.num);
+              moves[move.id] = [...new Set([...moves[move.id] ?? [], ...filtered])];
             }
           }
         }


### PR DESCRIPTION
Fixes #14

This is a naive merge that only prevents exact duplicates.

It leads to this learnset for gen 8 Venusaur and Double-Edge: `['8L51', '8L45', '8L33']` because it now has the data for Venusaur, Ivysaur and Bulbasaur.

Special handling could be added for `Lx` to prevent that. I'm not so sure what should be done about `Sx` (special event distributions) which could have a similar issue.