### PR TITLE
@pkmn/dex: special handling for gmax moves (all of them have num = 1000)

### DIFF
--- a/dex/index.test.ts
+++ b/dex/index.test.ts
@@ -140,6 +140,7 @@ describe('Dex', () => {
       expect(Dex.moves.get('Crunch').category).toBe('Physical');
       expect(Dex.forGen(2).moves.get('CRUNCH').category).toBe('Special');
       expect(Dex.moves.get('Hidden Power [Bug]').name).toBe('Hidden Power Bug');
+      expect(Dex.forGen(8).moves.get('G-Max Befuddle').exists).toBe(true);
     });
 
     it('fields', () => {
@@ -189,6 +190,7 @@ describe('Dex', () => {
       expect(Dex.moves.get('Feint').breaksProtect).toBe(true);
       expect(Dex.moves.get('Sacred Sword').ignoreDefensive).toBe(true);
       expect(Dex.moves.get('Fissure').ohko).toBe(true);
+      expect(Dex.forGen(8).moves.get('G-Max Befuddle').isNonstandard).toBe('Gigantamax');
 
       // self
       expect(Dex.moves.get('Petal Dance').self!.volatileStatus).toBe('lockedmove');

--- a/dex/index.ts
+++ b/dex/index.ts
@@ -525,7 +525,8 @@ export class Move extends BasicEffect<T.MoveName> implements T.Move {
       }
     }
     if (!this.gen) {
-      if (this.num >= 827) {
+      // special handling for gen8 gmax moves (all of them have num 1000 but they are part of gen8)
+      if (this.num >= 827 && !this.isMax) {
         this.gen = 9;
       } else if (this.num >= 743) {
         this.gen = 8;


### PR DESCRIPTION
Fixes #17

Just a quick fix that worked for me.

Not sure what showdown will do when actual numbers reach 1000. The hope is that using `isMax` makes it more robust than checking for `num === 1000` but it could still break in the future anyway.