### PR TITLE
Fix cosmetic formes not having isCosmeticForme field set when generat…

### DIFF
--- a/dex/index.ts
+++ b/dex/index.ts
@@ -865,6 +865,7 @@ class DexSpecies implements T.DexTable<Species> {
                 baseSpecies: species.name,
                 otherFormes: null,
                 cosmeticFormes: null,
+                isCosmeticForme: true,
               });
               break;
             }


### PR DESCRIPTION
Fix cosmetic formes not having isCosmeticForme field set when generated from species.cosmeticFormes

Example
<img width="592" height="756" alt="image" src="https://github.com/user-attachments/assets/624ace59-e398-44dc-b5ab-1f4c0964023e" />
