### PR TITLE
Improve mod creation

### DIFF
--- a/sim/sim/dex.ts
+++ b/sim/sim/dex.ts
@@ -145,7 +145,7 @@ type DeepPartial<T> = {
 			: DeepPartial<T[P]>
 };
 
-export type ModData = DeepPartial<ModdedDex['data']>;
+export type ModData = DeepPartial<ModdedDex['data']> & {Formats?: FormatList};
 
 export const toID = Data.toID;
 
@@ -217,7 +217,7 @@ export class ModdedDex {
 		return dexes;
 	}
 
-	mod(mod: string | undefined, modData?: DeepPartial<ModdedDex['data']> & {Formats?: FormatList}): ModdedDex {
+	mod(mod: string | undefined, modData?: ModData): ModdedDex {
 		if (!mod) return dexes['base'];
 		const modid = toID(mod);
 		if (modData?.Types && !modData.TypeChart) modData.TypeChart = modData.Types;
@@ -325,10 +325,10 @@ export class ModdedDex {
 		const typeData = this.types.get(targetTyping);
 		if (!typeData) return 0;
 		switch (typeData.damageTaken[sourceType]) {
-		case 1: return 1; // super-effective
-		case 2: return -1; // resist
-		// in case of weird situations like Gravity, immunity is handled elsewhere
-		default: return 0;
+			case 1: return 1; // super-effective
+			case 2: return -1; // resist
+			// in case of weird situations like Gravity, immunity is handled elsewhere
+			default: return 0;
 		}
 	}
 
@@ -427,7 +427,7 @@ export class ModdedDex {
 	loadDataFile(
 		mod: string,
 		dataType: DataType,
-		modData?: DeepPartial<ModdedDex['data']>
+		modData?: ModData
 	): AnyObject | void {
 		if (modData) return modData[dataType];
 		return (dexData as any)[mod === 'base' ? BASE_MOD : mod][dataType];
@@ -464,7 +464,7 @@ export class ModdedDex {
 		return this;
 	}
 
-	loadData(modData?: DeepPartial<ModdedDex['data']>): DexTableData {
+	loadData(modData?: ModData): DexTableData {
 		if (this.dataCache) return this.dataCache;
 		const dataCache: {[k in keyof DexTableData]?: any} = {};
 


### PR DESCRIPTION
This improves mod creation by adding an optional `FormatList` to the `ModData` type. Currently, since the `FormatList` type isn't exported, I'm having to create a `ModDefinition` type from the second parameter of the `Dex.mod` function, like this:

```ts
import { Dex } from '@pkmn/sim';

type ModDefinition = NonNullable<Parameters<typeof Dex.mod>[1]>;

const baseFormat = Dex.formats.get("gen9customgame");
export const PKMN_MOD_DATA: ModDefinition = {
  Scripts: {
    inherit: baseFormat.mod,
    gen: 9,
  },
  Formats: [
    {
      name: "PKMN GD",
      mod: PKMN_MOD_ID,
      gameType: baseFormat.gameType,
      debug: baseFormat.debug,
      rated: false,
      ruleset: [baseFormat.name],
    },
  ],
};

export const PKMN_SIM_DEX = Dex.mod(PKMN_MOD_ID, PKMN_MOD_DATA);
```

This is not nice. The type change in this PR allows us to pass the `ModData` type as the second parameter in `Dex.mod`, which makes the code simpler:

```ts
import { Dex, type ModData } from '@pkmn/sim';

const baseFormat = Dex.formats.get("gen9customgame");
export const PKMN_MOD_DATA = {
  Scripts: {
    inherit: baseFormat.mod,
    gen: 9,
  },
  Formats: [
    {
      name: "PKMN GD",
      mod: PKMN_MOD_ID,
      gameType: baseFormat.gameType,
      debug: baseFormat.debug,
      rated: false,
      ruleset: [baseFormat.name],
    },
  ],
} satisfies ModData;

export const PKMN_SIM_DEX = Dex.mod(PKMN_MOD_ID, PKMN_MOD_DATA);
```